### PR TITLE
fix fqdn() func problem

### DIFF
--- a/types.go
+++ b/types.go
@@ -327,5 +327,5 @@ func split255(s string) []string {
 }
 
 func (rec *Record) fqdn() string {
-	return rec.Zone + rec.Name
+	return rec.Name + "." + rec.Zone
 }


### PR DESCRIPTION
Thank you very much for the plugin, I found this problem when I used it。
```$ dig @172.22.208.1 -p 1053 foo.example.org

; <<>> DiG 9.11.3-1ubuntu1.7-Ubuntu <<>> @172.22.208.1 -p 1053 foo.example.org
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 53943
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; COOKIE: e646d08a8bca9785 (echoed)
;; QUESTION SECTION:
;foo.example.org.               IN      A

;; ANSWER SECTION:
example.org.foo     49      IN      A       1.1.1.0

;; Query time: 0 msec
;; SERVER: 172.22.208.1#1053(172.22.208.1)
;; WHEN: Thu Oct 28 16:50:35 CST 2021
;; MSG SIZE  rcvd: 87
```
The answer section fqdn is wrong.
So I fix it,please merge it,thanks.