### PR TITLE
An attempt to fix the SOA authority section.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -60,6 +60,14 @@ func (handler *CoreDNSMySql) ServeDNS(ctx context.Context, w dns.ResponseWriter,
 		records = append(records, recs...)
 	}
 
+    if qType == "SOA" {
+		recsNs, err := handler.findRecord(qZone, qName, "NS")
+		if err != nil {
+			return handler.errorResponse(state, dns.RcodeServerFailure, err)
+		}
+		records = append(records, recsNs...)
+	}
+
 	if qType == "AXFR" {
 		return handler.errorResponse(state, dns.RcodeNotImplemented, nil)
 	}


### PR DESCRIPTION
This is as close as I can come to fixing Issue #15 .  Now all the NS records show up when doing a SOA dig but all of the NS records show up under the ANSWER SECTION when they should show up under the AUTHORITY section.  Don't merge this fix.